### PR TITLE
Modified implementation of maximum number of sensors

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=BresserWeatherSensorReceiver
-version=0.28.5
+version=0.28.6
 author=Matthias Prinke <matthias-bs@web.de>
 maintainer=Matthias Prinke <matthias-bs@web.de>
 sentence=Bresser 5-in-1/6-in-1/7-in-1 868 MHz Weather Sensor Radio Receiver for Arduino based on CC1101, SX1276/RFM95W or SX1262.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "BresserWeatherSensorReceiver",
-  "version": "0.28.5",
+  "version": "0.28.6",
   "description": "Bresser 5-in-1/6-in-1/7-in-1 868 MHz Weather Sensor Radio Receiver for Arduino based on CC1101, SX1276/RFM95W or SX1262",
   "main": "WeatherSensor.cpp",
   "frameworks": "arduino",

--- a/src/WeatherSensor.cpp
+++ b/src/WeatherSensor.cpp
@@ -99,6 +99,7 @@
 //          - Sensor data decoding functions (WeatherSensorDecoders.cpp)
 //          - Run-time configuration functions (WeatherSensorConfig.cpp)
 // 20240528 Fixed channel comparison in findType()
+// 20240608 Modified implementation of maximum number of sensors
 //
 // ToDo:
 // -
@@ -133,8 +134,9 @@ void
     receivedFlag = true;
 }
 
-int16_t WeatherSensor::begin(void)
+int16_t WeatherSensor::begin(uint8_t max_sensors_default)
 {
+    uint8_t maxSensorsDefault = max_sensors_default;
     uint8_t maxSensors;
     getSensorsCfg(maxSensors, rxFlags, enDecoders);
     log_d("max_sensors: %u", maxSensors);

--- a/src/WeatherSensor.h
+++ b/src/WeatherSensor.h
@@ -79,6 +79,7 @@
 // 20240417 Added sensor configuration at run time
 // 20240506 Changed sensor from array to std::vector, added getSensorCfg() / setSensorCfg()
 // 20240507 Added configuration of enabled decoders at run time
+// 20240608 Modified implementation of maximum number of sensors
 //
 // ToDo:
 // -
@@ -171,6 +172,7 @@ class WeatherSensor {
         Preferences cfgPrefs; //!< Preferences (stored in flash memory)
         std::vector<uint32_t> sensor_ids_inc;
         std::vector<uint32_t> sensor_ids_exc;
+        uint8_t maxSensorsDefault;
 
     public:
         /*!
@@ -178,7 +180,7 @@ class WeatherSensor {
 
         \returns RADIOLIB_ERR_NONE on success (otherwise does never return).
         */
-        int16_t begin(void);
+        int16_t begin(uint8_t max_sensors_default = MAX_SENSORS_DEFAULT);
 
         /*!
         \brief Reset radio transceiver

--- a/src/WeatherSensorConfig.cpp
+++ b/src/WeatherSensorConfig.cpp
@@ -37,6 +37,7 @@
 // History:
 //
 // 20240513 Created from WeatherSensor.cpp
+// 20240608 Modified implementation of maximum number of sensors
 //
 //
 // ToDo:
@@ -179,7 +180,7 @@ void WeatherSensor::setSensorsCfg(uint8_t max_sensors, uint8_t rx_flags, uint8_t
 void WeatherSensor::getSensorsCfg(uint8_t &max_sensors, uint8_t &rx_flags, uint8_t &en_decoders)
 {
     cfgPrefs.begin("BWS-CFG", false);
-    max_sensors = cfgPrefs.getUChar("maxsensors", MAX_SENSORS_DEFAULT);
+    max_sensors = cfgPrefs.getUChar("maxsensors", maxSensorsDefault);
     rx_flags = cfgPrefs.getUChar("rxflags", DATA_COMPLETE);
     en_decoders = cfgPrefs.getUChar("endec", 0xFF);
     cfgPrefs.end();


### PR DESCRIPTION
The default maximum number of sensors (which is applied if no setting has been found in Preferences) can now be set with `begin(max_number)`.