### PR TITLE
Changed `depends` in library.properties to exactly match package.json

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Bresser 5-in-1/6-in-1/7-in-1 868 MHz Weather Sensor Radio Receiver for 
 paragraph=Bresser 5-in-1/6-in-1/7-in-1 868 MHz Weather Sensor Radio Receiver for Arduino based on CC1101, SX1276/RFM95W or SX1262.
 category=Sensors
 url=https://github.com/matthias-bs/BresserWeatherSensorReceiver
-depends=RadioLib,MQTT,ArduinoJson,Preferences
+depends=jgromes/RadioLib#semver:^7.1.0,thesolarnomad/lora-serialization#semver:^3.3.1,256dpi/arduino-mqtt#semver:^2.5.2,bblanchon/ArduinoJson#semver:^7.2.0,tzapu/WiFiManager#semver:2.0.17,khoih-prog/ESP_DoubleResetDetector#semver:1.3.2,vshymanskyy/Preferences#semver:^2.1.0
 architectures=esp32,esp8266,rp2040


### PR DESCRIPTION
This adds some more libraries and fixes some "Warning! More than one package has been found by MQTT requirements:" warnings with platform.io

Tested with current platform.io 
```sh
$ pio pkg install -f 
[....]
Library Manager: Installing file:///home/******/BresserWeatherSensorReceiver
Library Manager: BresserWeatherSensorReceiver@0.28.10 has been installed!
Library Manager: Resolving dependencies...
Library Manager: Installing jgromes/RadioLib#semver:^7.1.0
Library Manager: Installing thesolarnomad/lora-serialization#semver:^3.3.1
Library Manager: Installing 256dpi/arduino-mqtt#semver:^2.5.2
Library Manager: Installing bblanchon/ArduinoJson#semver:^7.2.0
Library Manager: Installing tzapu/WiFiManager#semver:2.0.17
Library Manager: Installing khoih-prog/ESP_DoubleResetDetector#semver:1.3.2
Library Manager: Installing vshymanskyy/Preferences#semver:^2.1.0
```

I tried to test this with the Arduino IDE, but couldn't figure out how to convince it to use my "private" library to trigger the dependency management.
