### PR TITLE
[Frequency] Added an option to set a frequency offset

### DIFF
--- a/src/WeatherSensor.cpp
+++ b/src/WeatherSensor.cpp
@@ -136,7 +136,7 @@ void
     receivedFlag = true;
 }
 
-int16_t WeatherSensor::begin(uint8_t max_sensors_default, bool init_filters)
+int16_t WeatherSensor::begin(uint8_t max_sensors_default, bool init_filters, double frequency_offset)
 {
     uint8_t maxSensors = max_sensors_default;
     getSensorsCfg(maxSensors, rxFlags, enDecoders);
@@ -165,12 +165,15 @@ int16_t WeatherSensor::begin(uint8_t max_sensors_default, bool init_filters)
 // Rx bandwidth:                        270.0 kHz (CC1101) / 250 kHz (SX1276) / 234.3 kHz (SX1262)
 // output power:                        10 dBm
 // preamble length:                     40 bits
+    double frequency = 868.3 + frequency_offset;
+    log_d("Setting frequency to %f MHz", 868.3 + frequency_offset);
+
 #ifdef USE_CC1101
-    int state = radio.begin(868.3, 8.21, 57.136417, 270, 10, 32);
+    int state = radio.begin(frequency, 8.21, 57.136417, 270, 10, 32);
 #elif defined(USE_SX1276)
-    int state = radio.beginFSK(868.3, 8.21, 57.136417, 250, 10, 32);
+    int state = radio.beginFSK(frequency, 8.21, 57.136417, 250, 10, 32);
 #else
-    int state = radio.beginFSK(868.3, 8.21, 57.136417, 234.3, 10, 32);
+    int state = radio.beginFSK(frequency, 8.21, 57.136417, 234.3, 10, 32);
 #endif
     if (state == RADIOLIB_ERR_NONE)
     {

--- a/src/WeatherSensor.h
+++ b/src/WeatherSensor.h
@@ -183,7 +183,7 @@ class WeatherSensor {
 
         \returns RADIOLIB_ERR_NONE on success (otherwise does never return).
         */
-        int16_t begin(uint8_t max_sensors_default = MAX_SENSORS_DEFAULT, bool init_filters = true);
+        int16_t begin(uint8_t max_sensors_default = MAX_SENSORS_DEFAULT, bool init_filters = true, double frequency_offset = 0.0);
 
         /*!
         \brief Reset radio transceiver


### PR DESCRIPTION
Some CC1101 are crappy and don't work exactly on 868.3 Mhz although set. Mine e.g. needs a setting of 868.35 to see my sender properly. This adds a parameter to begin() to specify the offset.