### PR TITLE
[Debugging] Prevent redefine of CORE_DEBUG_LEVEL if already defined elsewhere

### DIFF
--- a/src/WeatherSensorCfg.h
+++ b/src/WeatherSensorCfg.h
@@ -328,8 +328,10 @@
         #define DEBUG_PORT DEBUG_ESP_PORT
     #endif
     
-    // Set desired level here!
-    #define CORE_DEBUG_LEVEL ARDUHAL_LOG_LEVEL_INFO
+    // Set desired level here if not defined elsewhere!
+    #if !defined(CORE_DEBUG_LEVEL)
+        #define CORE_DEBUG_LEVEL ARDUHAL_LOG_LEVEL_INFO
+    #endif
 
     #if defined(DEBUG_PORT) && CORE_DEBUG_LEVEL > ARDUHAL_LOG_LEVEL_NONE
         #define log_e(...) { DEBUG_PORT.printf("%s(), l.%d: ",__func__, __LINE__); DEBUG_PORT.printf(__VA_ARGS__); DEBUG_PORT.println(); }


### PR DESCRIPTION
This enables you #define the desired debug level in your source-file or build flags.

e.g. with a setting in `platform.io` like

```ìni
build_flags =
  -D USE_CC1101
  -D ESP8266
  -D DEBUG_PORT=Serial
  -D CORE_DEBUG_LEVEL=5
```
Like this you can change the debug level without touching the source files.