### PR TITLE
Bugfix in reset reason handling on ESP8266 platform in example

### DIFF
--- a/examples/BresserWeatherSensorMQTTWifiMgr/BresserWeatherSensorMQTTWifiMgr.ino
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/BresserWeatherSensorMQTTWifiMgr.ino
@@ -982,11 +982,13 @@ void setup()
     initBoard();
     log_i("\n\n%s\n", sketch_id);
 
+#if defined(ESP32)
     // Detect reset reason:
     // see
     // https://github.com/espressif/arduino-esp32/blob/master/libraries/ESP32/examples/ResetReason/ResetReason.ino
     log_d("CPU0 reset reason: %d", rtc_get_reset_reason(0));
     log_d("CPU1 reset reason: %d", rtc_get_reset_reason(1));
+#endif
 
     // Set time zone
     setenv("TZ", TZ_INFO, 1);
@@ -1027,6 +1029,7 @@ void setup()
     #elif defined(ESP8266)
         rst_info *resetInfo;
         resetInfo = ESP.getResetInfoPtr();
+        log_d("Reset Reason: %d", resetInfo->reason);
         bool hw_reset = (resetInfo->reason == REASON_EXT_SYS_RST);
     #endif
 


### PR DESCRIPTION
`rtc_get_reset_reason()` is only available on ESP32 platform, this fails to compile with platform ESP8266. It's thus now wrapped in the needed `#ifdef` and the debug output for the reset reason is in the handling of hardware reset for the ESP8266 further down.