### PR TITLE
Small fixes to BresserWeatherSensorMQTTWifiMgr

### DIFF
--- a/examples/BresserWeatherSensorMQTTWifiMgr/BresserWeatherSensorMQTTWifiMgr.ino
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/BresserWeatherSensorMQTTWifiMgr.ino
@@ -181,7 +181,8 @@
 #define WIFI_RETRIES 10       // WiFi connection retries
 #define WIFI_DELAY 1000       // Delay between connection attempts [ms]
 #define SLEEP_EN true         // enable sleep mode (see notes above!)
-#define AUTO_DISCOVERY        // enable Home Assistant auto discovery
+#define AUTO_DISCOVERY        // enable Home Assistant auto discovery (you can save some  
+                              // memory by disabling AUTO_DISCOVERY_CODE in mqtt_comm.h as well)
 // #define USE_SECUREWIFI          // use secure WIFI
 #define USE_WIFI // use non-secure WIFI
 // Enter your time zone (https://remotemonitoringsystems.ca/time-zone-abbreviations.php)

--- a/examples/BresserWeatherSensorMQTTWifiMgr/BresserWeatherSensorMQTTWifiMgr.ino
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/BresserWeatherSensorMQTTWifiMgr.ino
@@ -181,8 +181,7 @@
 #define WIFI_RETRIES 10       // WiFi connection retries
 #define WIFI_DELAY 1000       // Delay between connection attempts [ms]
 #define SLEEP_EN true         // enable sleep mode (see notes above!)
-#define AUTO_DISCOVERY        // enable Home Assistant auto discovery (you can save some  
-                              // memory by disabling AUTO_DISCOVERY_CODE in mqtt_comm.h as well)
+#define AUTO_DISCOVERY        // enable Home Assistant auto discovery
 // #define USE_SECUREWIFI          // use secure WIFI
 #define USE_WIFI // use non-secure WIFI
 // Enter your time zone (https://remotemonitoringsystems.ca/time-zone-abbreviations.php)

--- a/examples/BresserWeatherSensorMQTTWifiMgr/BresserWeatherSensorMQTTWifiMgr.ino
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/BresserWeatherSensorMQTTWifiMgr.ino
@@ -173,10 +173,11 @@
 #define RX_TIMEOUT 90000      // sensor receive timeout [ms]
 #define STATUS_INTERVAL 30000 // MQTT status message interval [ms]
 #define DATA_INTERVAL 15000   // MQTT data message interval [ms]
+//#define DATA_TIMESTAMP      // add timestamp to published Weatherdata
+#define RESET_SUBSCRIBE       // subscribe to reset topic
 #define DISCOVERY_INTERVAL 30 // Home Assistant auto discovery interval [min]
 #define AWAKE_TIMEOUT 300000  // maximum time until sketch is forced to sleep [ms]
 #define SLEEP_INTERVAL 300000 // sleep interval [ms]
-//#define RESET_SUBSCRIBE       // subscribe to reset topic
 #define WIFI_RETRIES 10       // WiFi connection retries
 #define WIFI_DELAY 1000       // Delay between connection attempts [ms]
 #define SLEEP_EN true         // enable sleep mode (see notes above!)

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
@@ -138,7 +138,6 @@ void publishWeatherdata(bool complete, bool retain)
         mqtt_payload = "";
         mqtt_payload2 = "";
 
-
         if (!weatherSensor.sensor[i].valid)
             continue;
 
@@ -158,7 +157,7 @@ void publishWeatherdata(bool complete, bool retain)
         mqtt_payload += String(",\"ch\":") + String(weatherSensor.sensor[i].chan);
         mqtt_payload += String(",\"battery_ok\":") + (weatherSensor.sensor[i].battery_ok ? String("1") : String("0"));
 
-		#if defined(DATA_TIMESTAMP)
+        #if defined(DATA_TIMESTAMP)
         {
             // Generate timestamp in ISO 8601 format
             time_t now = time(nullptr);
@@ -168,7 +167,7 @@ void publishWeatherdata(bool complete, bool retain)
             strftime(tbuf, sizeof(tbuf), "%Y-%m-%dT%H:%M:%SZ", &timeinfo); // Format as ISO 8601
             mqtt_payload += String(",\"timestamp\":\"") + String(tbuf) + String("\"");
         }
-		#endif // DATA_TIMESTAMP
+        #endif // DATA_TIMESTAMP
 
         if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_SOIL)
         {

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
@@ -365,7 +365,7 @@ void publishRadio(void)
     payload.clear();
 }
 
-#if defined(AUTO_DISCOVERY)
+#if defined(AUTO_DISCOVERY_CODE)
 // Home Assistant Auto-Discovery
 void haAutoDiscovery(void)
 {
@@ -648,4 +648,4 @@ void publishAutoDiscovery(const struct sensor_info info, const char *sensor_name
     client.publish(topic, buffer, true /* retained */, 0 /* qos */);
     log_d("Published auto-discovery configuration for %s", sensor_name);
 }
-#endif // AUTO_DISCOVERY
+#endif // AUTO_DISCOVERY_CODE

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
@@ -158,6 +158,7 @@ void publishWeatherdata(bool complete, bool retain)
         mqtt_payload += String(",\"ch\":") + String(weatherSensor.sensor[i].chan);
         mqtt_payload += String(",\"battery_ok\":") + (weatherSensor.sensor[i].battery_ok ? String("1") : String("0"));
 
+		#if defined(DATA_TIMESTAMP)
         {
             // Generate timestamp in ISO 8601 format
             time_t now = time(nullptr);
@@ -167,6 +168,7 @@ void publishWeatherdata(bool complete, bool retain)
             strftime(tbuf, sizeof(tbuf), "%Y-%m-%dT%H:%M:%SZ", &timeinfo); // Format as ISO 8601
             mqtt_payload += String(",\"timestamp\":\"") + String(tbuf) + String("\"");
         }
+		#endif // DATA_TIMESTAMP
 
         if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_SOIL)
         {

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
@@ -38,6 +38,7 @@
 // 20250221 Created from BresserWeatherSensorMQTT.ino
 // 20250227 Added publishControlDiscovery()
 // 20250228 Added publishStatusDiscovery(), fixed sensorName()
+// 20250420 Added timestamp to measument data,fixed base-topic in extra data
 //
 // ToDo:
 // -
@@ -137,6 +138,7 @@ void publishWeatherdata(bool complete, bool retain)
         mqtt_payload = "";
         mqtt_payload2 = "";
 
+
         if (!weatherSensor.sensor[i].valid)
             continue;
 
@@ -155,6 +157,16 @@ void publishWeatherdata(bool complete, bool retain)
         mqtt_payload += String("\"id\":") + String(weatherSensor.sensor[i].sensor_id);
         mqtt_payload += String(",\"ch\":") + String(weatherSensor.sensor[i].chan);
         mqtt_payload += String(",\"battery_ok\":") + (weatherSensor.sensor[i].battery_ok ? String("1") : String("0"));
+
+        {
+            // Generate timestamp in ISO 8601 format
+            time_t now = time(nullptr);
+            struct tm timeinfo;
+            gmtime_r(&now, &timeinfo); // Convert to UTC time
+            char tbuf[25];
+            strftime(tbuf, sizeof(tbuf), "%Y-%m-%dT%H:%M:%SZ", &timeinfo); // Format as ISO 8601
+            mqtt_payload += String(",\"timestamp\":\"") + String(tbuf) + String("\"");
+        }
 
         if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_SOIL)
         {
@@ -327,7 +339,7 @@ void publishWeatherdata(bool complete, bool retain)
         client.publish(mqtt_topic, String(weatherSensor.sensor[i].rssi, 1), false, 0);
 
         // extra data
-        mqtt_topic = mqttPubExtra;
+        mqtt_topic = mqtt_topic_base + mqttPubExtra;
 
         if (mqtt_payload2.length() > 2)
         {

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
@@ -364,7 +364,6 @@ void publishRadio(void)
     payload.clear();
 }
 
-#if defined(AUTO_DISCOVERY_CODE)
 // Home Assistant Auto-Discovery
 void haAutoDiscovery(void)
 {
@@ -647,4 +646,3 @@ void publishAutoDiscovery(const struct sensor_info info, const char *sensor_name
     client.publish(topic, buffer, true /* retained */, 0 /* qos */);
     log_d("Published auto-discovery configuration for %s", sensor_name);
 }
-#endif // AUTO_DISCOVERY_CODE

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
@@ -49,7 +49,8 @@
 #define MQTT_COMM_H
 
 #define PAYLOAD_SIZE 300      // maximum MQTT message size
-#define AUTO_DISCOVERY_CODE        // enable Home Assistant auto discovery
+#define AUTO_DISCOVERY_CODE   // enable Home Assistant auto discovery (only code enabled,
+                              // enable feature in ino-file as well)
 
 #include <Arduino.h>
 #include <string>

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
@@ -49,8 +49,6 @@
 #define MQTT_COMM_H
 
 #define PAYLOAD_SIZE 300      // maximum MQTT message size
-#define AUTO_DISCOVERY_CODE   // enable Home Assistant auto discovery (only code enabled,
-                              // enable feature in ino-file as well)
 
 #include <Arduino.h>
 #include <string>
@@ -119,7 +117,6 @@ void publishWeatherdata(bool complete = false, bool retain = false);
  */
 void publishRadio(void);
 
-#if defined(AUTO_DISCOVERY_CODE)
 /*!
  * \brief Home Assistant Auto-Discovery
  *
@@ -156,5 +153,4 @@ void publishStatusDiscovery(String name, String topic);
  */
 void publishControlDiscovery(String name, String topic);
 
-#endif // AUTO_DISCOVERY_CODE
 #endif // MQTT_COMM_H

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
@@ -38,6 +38,7 @@
 // 20250221 Created from BresserWeatherSensorMQTT.ino
 // 20250226 Added parameter 'retain' to publishWeatherdata()
 // 20250227 Added publishControlDiscovery()
+// 20250420 removed AUTO_DISCOVERY here, as it is defined in sketch
 //
 // ToDo:
 // -
@@ -48,7 +49,7 @@
 #define MQTT_COMM_H
 
 #define PAYLOAD_SIZE 300      // maximum MQTT message size
-#define AUTO_DISCOVERY        // enable Home Assistant auto discovery
+//#define AUTO_DISCOVERY        // enable Home Assistant auto discovery
 
 #include <Arduino.h>
 #include <string>

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
@@ -49,7 +49,7 @@
 #define MQTT_COMM_H
 
 #define PAYLOAD_SIZE 300      // maximum MQTT message size
-//#define AUTO_DISCOVERY        // enable Home Assistant auto discovery
+#define AUTO_DISCOVERY_CODE        // enable Home Assistant auto discovery
 
 #include <Arduino.h>
 #include <string>
@@ -118,7 +118,7 @@ void publishWeatherdata(bool complete = false, bool retain = false);
  */
 void publishRadio(void);
 
-#if defined(AUTO_DISCOVERY)
+#if defined(AUTO_DISCOVERY_CODE)
 /*!
  * \brief Home Assistant Auto-Discovery
  *
@@ -155,5 +155,5 @@ void publishStatusDiscovery(String name, String topic);
  */
 void publishControlDiscovery(String name, String topic);
 
-#endif // AUTO_DISCOVERY
+#endif // AUTO_DISCOVERY_CODE
 #endif // MQTT_COMM_H


### PR DESCRIPTION
I am using a cloud provider for MQTT and can assign user rights for each MQTT user. I only want to publish with the weather station user, and if it gets compromised, no subscriptions should be possible for that user. Therefore, I added an option to prevent subscribing to the reset topic. The provider uses a very long virtual server subdomain, so I extended the MQTT hostname length to 55. The cloud provider is sometimes not very performant, so I added a timestamp to the measurement data to record the actual time when it was collected. Since I want to save data using the cloud, which is by MB, I removed AUTO_DISCOVERY as the default in mqtt_comm, as it is redundantly defined and the definition in the sketch should suffice.

During testing, I frequently encountered WDT resets. To address this, I added yield() to clientLoopWrapper to avoid WDT resets during prolonged operations.

Additionally, the extra data no longer included the base topic in mqtt_comm, so I added it to the extra data. 