### PR TITLE
Fix HA auto-discovery device merging and add user-defined device names

### DIFF
--- a/examples/BresserWeatherSensorMQTT/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTT/src/mqtt_comm.cpp
@@ -65,6 +65,7 @@
 //          to const char*, updated function signatures to const char* where applicable.
 // 20260510 Fixed HA device identifier collision: multiple sensors of the same type now each
 //          get a unique identifier derived from sensor_id.
+//          Added display_name to sensor_info: HA device name now uses sensor_map name when set.
 //
 // ToDo:
 // -
@@ -461,7 +462,8 @@ void haAutoDiscovery(void)
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Weather Sensor",
-                .identifier = identifier};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -516,7 +518,8 @@ void haAutoDiscovery(void)
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Soil Sensor",
-                .identifier = identifier};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -530,7 +533,8 @@ void haAutoDiscovery(void)
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Thermo-Hygrometer Sensor",
-                .identifier = identifier};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -544,7 +548,8 @@ void haAutoDiscovery(void)
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Pool Thermometer",
-                .identifier = identifier};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -557,7 +562,8 @@ void haAutoDiscovery(void)
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (PM) Sensor",
-                .identifier = identifier};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -572,7 +578,8 @@ void haAutoDiscovery(void)
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Lightning Sensor",
-                .identifier = identifier};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -587,7 +594,8 @@ void haAutoDiscovery(void)
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Leakage Sensor",
-                .identifier = identifier};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -600,7 +608,8 @@ void haAutoDiscovery(void)
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "CO2 Sensor",
-                .identifier = identifier};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -613,7 +622,8 @@ void haAutoDiscovery(void)
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (HCHO/VOC) Sensor",
-                .identifier = identifier};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -771,7 +781,10 @@ void publishAutoDiscovery(const struct sensor_info info, const char *sensor_name
     JsonObject device = doc["device"].to<JsonObject>();
     device["identifiers"] = info.identifier;
     char deviceName[80];
-    snprintf(deviceName, sizeof(deviceName), "%s %s", info.manufacturer, info.model);
+    if (info.display_name && info.display_name[0] != '\0')
+        snprintf(deviceName, sizeof(deviceName), "%s", info.display_name);
+    else
+        snprintf(deviceName, sizeof(deviceName), "%s %s", info.manufacturer, info.model);
     device["name"] = deviceName;
     if (info.model[0] != '\0')
         device["model"] = info.model;

--- a/examples/BresserWeatherSensorMQTT/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTT/src/mqtt_comm.cpp
@@ -63,6 +63,8 @@
 //          functions (publishAutoDiscovery, publishStatusDiscovery, publishControlDiscovery).
 //          Replaced String topic/rssi with stack char[]+snprintf, changed sensor_info members
 //          to const char*, updated function signatures to const char* where applicable.
+// 20260510 Fixed HA device identifier collision: multiple sensors of the same type now each
+//          get a unique identifier derived from sensor_id.
 //
 // ToDo:
 // -
@@ -454,10 +456,12 @@ void haAutoDiscovery(void)
             (weatherSensor.sensor[i].s_type == SENSOR_TYPE_WEATHER3) ||
             (weatherSensor.sensor[i].s_type == SENSOR_TYPE_WEATHER8))
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "weather_%08x", sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Weather Sensor",
-                .identifier = "weather_sensor_1"};
+                .identifier = identifier};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -507,10 +511,12 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_SOIL)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "soil_%08x", sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Soil Sensor",
-                .identifier = "soil_sensor_1"};
+                .identifier = identifier};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -519,10 +525,12 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_THERMO_HYGRO)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "thermo_hygro_%08x", sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Thermo-Hygrometer Sensor",
-                .identifier = "thermo_hygrometer_sensor_1"};
+                .identifier = identifier};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -531,10 +539,12 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_POOL_THERMO)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "pool_thermo_%08x", sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Pool Thermometer",
-                .identifier = "pool_thermometer_1"};
+                .identifier = identifier};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -542,10 +552,12 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_AIR_PM)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "air_pm_%08x", sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (PM) Sensor",
-                .identifier = "air_quality_sensor_1"};
+                .identifier = identifier};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -555,10 +567,12 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_LIGHTNING)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "lightning_%08x", sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Lightning Sensor",
-                .identifier = "lightning_sensor"};
+                .identifier = identifier};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -568,10 +582,12 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_LEAKAGE)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "leakage_%08x", sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Leakage Sensor",
-                .identifier = "leakage_sensor_1"};
+                .identifier = identifier};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -579,10 +595,12 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_CO2)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "co2_%08x", sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "CO2 Sensor",
-                .identifier = "co2_sensor_1"};
+                .identifier = identifier};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -590,10 +608,12 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_HCHO_VOC)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "hcho_voc_%08x", sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (HCHO/VOC) Sensor",
-                .identifier = "air_quality_sensor_2"};
+                .identifier = identifier};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");

--- a/examples/BresserWeatherSensorMQTT/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTT/src/mqtt_comm.cpp
@@ -83,7 +83,7 @@ extern RainGauge rainGauge;
 extern Lightning lightning;
 extern std::vector<SensorMap> sensor_map;
 
-void sensorName(uint32_t sensor_id, char* buf, size_t buf_size)
+bool sensorName(uint32_t sensor_id, char* buf, size_t buf_size)
 {
     snprintf(buf, buf_size, "%x", (unsigned)sensor_id);
     for (size_t n = 0; n < sensor_map.size(); n++)
@@ -91,9 +91,10 @@ void sensorName(uint32_t sensor_id, char* buf, size_t buf_size)
         if (sensor_map[n].id == sensor_id)
         {
             snprintf(buf, buf_size, "%s", sensor_map[n].name.c_str());
-            break;
+            return true;
         }
     }
+    return false;
 }
 
 // MQTT message received callback
@@ -446,7 +447,7 @@ void haAutoDiscovery(void)
             continue;
 
         char sensor_str[32];
-        sensorName(weatherSensor.sensor[i].sensor_id, sensor_str, sizeof(sensor_str));
+        bool named = sensorName(weatherSensor.sensor[i].sensor_id, sensor_str, sizeof(sensor_str));
         // Stack-allocated topic buffers avoid heap fragmentation from String concatenation.
         char topicData[128], topicRssi[128], topicExtra[128];
         snprintf(topicData,  sizeof(topicData),  "%s/%s/data",  Hostname.c_str(), sensor_str);
@@ -463,7 +464,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Weather Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -519,7 +520,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Soil Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -534,7 +535,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Thermo-Hygrometer Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -549,7 +550,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Pool Thermometer",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -563,7 +564,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Air Quality (PM) Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -579,7 +580,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Lightning Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -595,7 +596,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Leakage Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -609,7 +610,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "CO2 Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -623,7 +624,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Air Quality (HCHO/VOC) Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");

--- a/examples/BresserWeatherSensorMQTT/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTT/src/mqtt_comm.cpp
@@ -458,7 +458,7 @@ void haAutoDiscovery(void)
             (weatherSensor.sensor[i].s_type == SENSOR_TYPE_WEATHER8))
         {
             char identifier[32];
-            snprintf(identifier, sizeof(identifier), "weather_%08x", sensor_id);
+            snprintf(identifier, sizeof(identifier), "weather_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Weather Sensor",
@@ -514,7 +514,7 @@ void haAutoDiscovery(void)
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_SOIL)
         {
             char identifier[32];
-            snprintf(identifier, sizeof(identifier), "soil_%08x", sensor_id);
+            snprintf(identifier, sizeof(identifier), "soil_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Soil Sensor",
@@ -529,7 +529,7 @@ void haAutoDiscovery(void)
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_THERMO_HYGRO)
         {
             char identifier[32];
-            snprintf(identifier, sizeof(identifier), "thermo_hygro_%08x", sensor_id);
+            snprintf(identifier, sizeof(identifier), "thermo_hygro_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Thermo-Hygrometer Sensor",
@@ -544,7 +544,7 @@ void haAutoDiscovery(void)
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_POOL_THERMO)
         {
             char identifier[32];
-            snprintf(identifier, sizeof(identifier), "pool_thermo_%08x", sensor_id);
+            snprintf(identifier, sizeof(identifier), "pool_thermo_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Pool Thermometer",
@@ -558,7 +558,7 @@ void haAutoDiscovery(void)
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_AIR_PM)
         {
             char identifier[32];
-            snprintf(identifier, sizeof(identifier), "air_pm_%08x", sensor_id);
+            snprintf(identifier, sizeof(identifier), "air_pm_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (PM) Sensor",
@@ -574,7 +574,7 @@ void haAutoDiscovery(void)
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_LIGHTNING)
         {
             char identifier[32];
-            snprintf(identifier, sizeof(identifier), "lightning_%08x", sensor_id);
+            snprintf(identifier, sizeof(identifier), "lightning_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Lightning Sensor",
@@ -590,7 +590,7 @@ void haAutoDiscovery(void)
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_LEAKAGE)
         {
             char identifier[32];
-            snprintf(identifier, sizeof(identifier), "leakage_%08x", sensor_id);
+            snprintf(identifier, sizeof(identifier), "leakage_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Leakage Sensor",
@@ -604,7 +604,7 @@ void haAutoDiscovery(void)
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_CO2)
         {
             char identifier[32];
-            snprintf(identifier, sizeof(identifier), "co2_%08x", sensor_id);
+            snprintf(identifier, sizeof(identifier), "co2_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "CO2 Sensor",
@@ -618,7 +618,7 @@ void haAutoDiscovery(void)
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_HCHO_VOC)
         {
             char identifier[32];
-            snprintf(identifier, sizeof(identifier), "hcho_voc_%08x", sensor_id);
+            snprintf(identifier, sizeof(identifier), "hcho_voc_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (HCHO/VOC) Sensor",

--- a/examples/BresserWeatherSensorMQTT/src/mqtt_comm.h
+++ b/examples/BresserWeatherSensorMQTT/src/mqtt_comm.h
@@ -44,6 +44,7 @@
 // 20260403 Changed sensor_info members from String to const char* to avoid heap allocation
 //          in haAutoDiscovery(); changed publishStatusDiscovery/publishControlDiscovery
 //          parameters from String to const char*
+// 20260510 Added display_name to sensor_info for user-defined HA device names
 //
 // ToDo:
 // -
@@ -96,6 +97,7 @@ struct sensor_info
     const char* manufacturer;
     const char* model;
     const char* identifier;
+    const char* display_name; // optional: overrides "manufacturer model" as HA device name
 };
 
 /*!

--- a/examples/BresserWeatherSensorMQTT/src/mqtt_comm.h
+++ b/examples/BresserWeatherSensorMQTT/src/mqtt_comm.h
@@ -138,7 +138,7 @@ void haAutoDiscovery(void);
 /*!
  * \brief Publish auto-discovery configuration for Home Assistant
  *
- * \param info          Sensor information (manufacturer, model, identifier)
+ * \param info          Sensor information (manufacturer, model, identifier, optional display_name)
  * \param sensor_name   Sensor name (e.g. "Outside Temperature")
  * \param sensor_id     Sensor ID (unique)
  * \param device_class  Device class (e.g. temperature, humidity, etc.)

--- a/examples/BresserWeatherSensorMQTTCustom/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTTCustom/src/mqtt_comm.cpp
@@ -83,7 +83,7 @@ extern RainGauge rainGauge;
 extern Lightning lightning;
 extern std::vector<SensorMap> sensor_map;
 
-void sensorName(uint32_t sensor_id, char* buf, size_t buf_size)
+bool sensorName(uint32_t sensor_id, char* buf, size_t buf_size)
 {
     snprintf(buf, buf_size, "%x", (unsigned)sensor_id);
     for (size_t n = 0; n < sensor_map.size(); n++)
@@ -91,9 +91,10 @@ void sensorName(uint32_t sensor_id, char* buf, size_t buf_size)
         if (sensor_map[n].id == sensor_id)
         {
             snprintf(buf, buf_size, "%s", sensor_map[n].name.c_str());
-            break;
+            return true;
         }
     }
+    return false;
 }
 
 // MQTT message received callback
@@ -446,7 +447,7 @@ void haAutoDiscovery(void)
             continue;
 
         char sensor_str[32];
-        sensorName(weatherSensor.sensor[i].sensor_id, sensor_str, sizeof(sensor_str));
+        bool named = sensorName(weatherSensor.sensor[i].sensor_id, sensor_str, sizeof(sensor_str));
         // Stack-allocated topic buffers avoid heap fragmentation from String concatenation.
         char topicData[128], topicRssi[128], topicExtra[128];
         snprintf(topicData,  sizeof(topicData),  "%s/%s/data",  Hostname.c_str(), sensor_str);
@@ -463,7 +464,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Weather Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -519,7 +520,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Soil Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -534,7 +535,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Thermo-Hygrometer Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -549,7 +550,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Pool Thermometer",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -563,7 +564,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Air Quality (PM) Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -579,7 +580,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Lightning Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -595,7 +596,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Leakage Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -609,7 +610,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "CO2 Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -623,7 +624,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Air Quality (HCHO/VOC) Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");

--- a/examples/BresserWeatherSensorMQTTCustom/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTTCustom/src/mqtt_comm.cpp
@@ -63,6 +63,9 @@
 //          functions (publishAutoDiscovery, publishStatusDiscovery, publishControlDiscovery).
 //          Replaced String topic/rssi with stack char[]+snprintf, changed sensor_info members
 //          to const char*, updated function signatures to const char* where applicable.
+// 20260510 Fixed HA device identifier collision: multiple sensors of the same type now each
+//          get a unique identifier derived from sensor_id.
+//          Added display_name to sensor_info: HA device name now uses sensor_map name when set.
 //
 // ToDo:
 // -
@@ -454,10 +457,13 @@ void haAutoDiscovery(void)
             (weatherSensor.sensor[i].s_type == SENSOR_TYPE_WEATHER3) ||
             (weatherSensor.sensor[i].s_type == SENSOR_TYPE_WEATHER8))
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "weather_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Weather Sensor",
-                .identifier = "weather_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -507,10 +513,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_SOIL)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "soil_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Soil Sensor",
-                .identifier = "soil_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -519,10 +528,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_THERMO_HYGRO)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "thermo_hygro_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Thermo-Hygrometer Sensor",
-                .identifier = "thermo_hygrometer_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -531,10 +543,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_POOL_THERMO)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "pool_thermo_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Pool Thermometer",
-                .identifier = "pool_thermometer_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -542,10 +557,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_AIR_PM)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "air_pm_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (PM) Sensor",
-                .identifier = "air_quality_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -555,10 +573,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_LIGHTNING)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "lightning_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Lightning Sensor",
-                .identifier = "lightning_sensor"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -568,10 +589,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_LEAKAGE)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "leakage_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Leakage Sensor",
-                .identifier = "leakage_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -579,10 +603,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_CO2)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "co2_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "CO2 Sensor",
-                .identifier = "co2_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -590,10 +617,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_HCHO_VOC)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "hcho_voc_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (HCHO/VOC) Sensor",
-                .identifier = "air_quality_sensor_2"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -751,7 +781,10 @@ void publishAutoDiscovery(const struct sensor_info info, const char *sensor_name
     JsonObject device = doc["device"].to<JsonObject>();
     device["identifiers"] = info.identifier;
     char deviceName[80];
-    snprintf(deviceName, sizeof(deviceName), "%s %s", info.manufacturer, info.model);
+    if (info.display_name && info.display_name[0] != '\0')
+        snprintf(deviceName, sizeof(deviceName), "%s", info.display_name);
+    else
+        snprintf(deviceName, sizeof(deviceName), "%s %s", info.manufacturer, info.model);
     device["name"] = deviceName;
     if (info.model[0] != '\0')
         device["model"] = info.model;

--- a/examples/BresserWeatherSensorMQTTCustom/src/mqtt_comm.h
+++ b/examples/BresserWeatherSensorMQTTCustom/src/mqtt_comm.h
@@ -44,6 +44,7 @@
 // 20260403 Changed sensor_info members from String to const char* to avoid heap allocation
 //          in haAutoDiscovery(); changed publishStatusDiscovery/publishControlDiscovery
 //          parameters from String to const char*
+// 20260510 Added display_name to sensor_info for user-defined HA device names
 //
 // ToDo:
 // -
@@ -96,6 +97,7 @@ struct sensor_info
     const char* manufacturer;
     const char* model;
     const char* identifier;
+    const char* display_name; // optional: overrides "manufacturer model" as HA device name
 };
 
 /*!
@@ -136,7 +138,7 @@ void haAutoDiscovery(void);
 /*!
  * \brief Publish auto-discovery configuration for Home Assistant
  *
- * \param info          Sensor information (manufacturer, model, identifier)
+ * \param info          Sensor information (manufacturer, model, identifier, optional display_name)
  * \param sensor_name   Sensor name (e.g. "Outside Temperature")
  * \param sensor_id     Sensor ID (unique)
  * \param device_class  Device class (e.g. temperature, humidity, etc.)

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
@@ -83,7 +83,7 @@ extern RainGauge rainGauge;
 extern Lightning lightning;
 extern std::vector<SensorMap> sensor_map;
 
-void sensorName(uint32_t sensor_id, char* buf, size_t buf_size)
+bool sensorName(uint32_t sensor_id, char* buf, size_t buf_size)
 {
     snprintf(buf, buf_size, "%x", (unsigned)sensor_id);
     for (size_t n = 0; n < sensor_map.size(); n++)
@@ -91,9 +91,10 @@ void sensorName(uint32_t sensor_id, char* buf, size_t buf_size)
         if (sensor_map[n].id == sensor_id)
         {
             snprintf(buf, buf_size, "%s", sensor_map[n].name.c_str());
-            break;
+            return true;
         }
     }
+    return false;
 }
 
 // MQTT message received callback
@@ -446,7 +447,7 @@ void haAutoDiscovery(void)
             continue;
 
         char sensor_str[32];
-        sensorName(weatherSensor.sensor[i].sensor_id, sensor_str, sizeof(sensor_str));
+        bool named = sensorName(weatherSensor.sensor[i].sensor_id, sensor_str, sizeof(sensor_str));
         // Stack-allocated topic buffers avoid heap fragmentation from String concatenation.
         char topicData[128], topicRssi[128], topicExtra[128];
         snprintf(topicData,  sizeof(topicData),  "%s/%s/data",  Hostname.c_str(), sensor_str);
@@ -463,7 +464,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Weather Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -519,7 +520,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Soil Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -534,7 +535,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Thermo-Hygrometer Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -549,7 +550,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Pool Thermometer",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -563,7 +564,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Air Quality (PM) Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -579,7 +580,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Lightning Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -595,7 +596,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Leakage Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -609,7 +610,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "CO2 Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -623,7 +624,7 @@ void haAutoDiscovery(void)
                 .manufacturer = "Bresser",
                 .model = "Air Quality (HCHO/VOC) Sensor",
                 .identifier = identifier,
-                .display_name = sensor_str};
+                .display_name = named ? sensor_str : nullptr};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.cpp
@@ -63,6 +63,9 @@
 //          functions (publishAutoDiscovery, publishStatusDiscovery, publishControlDiscovery).
 //          Replaced String topic/rssi with stack char[]+snprintf, changed sensor_info members
 //          to const char*, updated function signatures to const char* where applicable.
+// 20260510 Fixed HA device identifier collision: multiple sensors of the same type now each
+//          get a unique identifier derived from sensor_id.
+//          Added display_name to sensor_info: HA device name now uses sensor_map name when set.
 //
 // ToDo:
 // -
@@ -454,10 +457,13 @@ void haAutoDiscovery(void)
             (weatherSensor.sensor[i].s_type == SENSOR_TYPE_WEATHER3) ||
             (weatherSensor.sensor[i].s_type == SENSOR_TYPE_WEATHER8))
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "weather_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Weather Sensor",
-                .identifier = "weather_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -507,10 +513,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_SOIL)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "soil_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Soil Sensor",
-                .identifier = "soil_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -519,10 +528,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_THERMO_HYGRO)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "thermo_hygro_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Thermo-Hygrometer Sensor",
-                .identifier = "thermo_hygrometer_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -531,10 +543,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_POOL_THERMO)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "pool_thermo_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Pool Thermometer",
-                .identifier = "pool_thermometer_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -542,10 +557,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_AIR_PM)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "air_pm_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (PM) Sensor",
-                .identifier = "air_quality_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -555,10 +573,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_LIGHTNING)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "lightning_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Lightning Sensor",
-                .identifier = "lightning_sensor"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -568,10 +589,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_LEAKAGE)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "leakage_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Leakage Sensor",
-                .identifier = "leakage_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -579,10 +603,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_CO2)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "co2_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "CO2 Sensor",
-                .identifier = "co2_sensor_1"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -590,10 +617,13 @@ void haAutoDiscovery(void)
         }
         else if (weatherSensor.sensor[i].s_type == SENSOR_TYPE_HCHO_VOC)
         {
+            char identifier[32];
+            snprintf(identifier, sizeof(identifier), "hcho_voc_%08x", (unsigned)sensor_id);
             struct sensor_info info = {
                 .manufacturer = "Bresser",
                 .model = "Air Quality (HCHO/VOC) Sensor",
-                .identifier = "air_quality_sensor_2"};
+                .identifier = identifier,
+                .display_name = sensor_str};
 
             publishAutoDiscovery(info, "Battery", sensor_id, "battery", "%", topicData, "battery_ok");
             publishAutoDiscovery(info, "RSSI", sensor_id, "signal_strength", "dBm", topicRssi, "rssi");
@@ -751,7 +781,10 @@ void publishAutoDiscovery(const struct sensor_info info, const char *sensor_name
     JsonObject device = doc["device"].to<JsonObject>();
     device["identifiers"] = info.identifier;
     char deviceName[80];
-    snprintf(deviceName, sizeof(deviceName), "%s %s", info.manufacturer, info.model);
+    if (info.display_name && info.display_name[0] != '\0')
+        snprintf(deviceName, sizeof(deviceName), "%s", info.display_name);
+    else
+        snprintf(deviceName, sizeof(deviceName), "%s %s", info.manufacturer, info.model);
     device["name"] = deviceName;
     if (info.model[0] != '\0')
         device["model"] = info.model;

--- a/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
+++ b/examples/BresserWeatherSensorMQTTWifiMgr/src/mqtt_comm.h
@@ -44,6 +44,7 @@
 // 20260403 Changed sensor_info members from String to const char* to avoid heap allocation
 //          in haAutoDiscovery(); changed publishStatusDiscovery/publishControlDiscovery
 //          parameters from String to const char*
+// 20260510 Added display_name to sensor_info for user-defined HA device names
 //
 // ToDo:
 // -
@@ -96,6 +97,7 @@ struct sensor_info
     const char* manufacturer;
     const char* model;
     const char* identifier;
+    const char* display_name; // optional: overrides "manufacturer model" as HA device name
 };
 
 /*!
@@ -136,7 +138,7 @@ void haAutoDiscovery(void);
 /*!
  * \brief Publish auto-discovery configuration for Home Assistant
  *
- * \param info          Sensor information (manufacturer, model, identifier)
+ * \param info          Sensor information (manufacturer, model, identifier, optional display_name)
  * \param sensor_name   Sensor name (e.g. "Outside Temperature")
  * \param sensor_id     Sensor ID (unique)
  * \param device_class  Device class (e.g. temperature, humidity, etc.)


### PR DESCRIPTION
## Summary

Two related improvements to `haAutoDiscovery()` in the three MQTT example sketches (`BresserWeatherSensorMQTT`, `BresserWeatherSensorMQTTCustom`, `BresserWeatherSensorMQTTWifiMgr`).

### Fix 1: Multiple sensors of the same type get merged into one HA device

Every sensor type used a hardcoded string as the HA device `identifier` (e.g. `"thermo_hygrometer_sensor_1"`). When multiple physical sensors of the same type are present, they all registered under the same HA device and overwrote each other's entities instead of appearing as separate devices.

The `unique_id` per entity was already correctly built from `sensor_id`, so individual entities were unique — only the device grouping was broken.

**Fix:** Build the `identifier` dynamically from `sensor_id` for each sensor type using a stack-allocated `char identifier[32]`:

```cpp
char identifier[32];
snprintf(identifier, sizeof(identifier), "thermo_hygro_%08x", (unsigned)sensor_id);
struct sensor_info info = {
    .manufacturer = "Bresser",
    .model        = "Thermo-Hygrometer Sensor",
    .identifier   = identifier,
    ...
};
```

All 9 sensor type branches are updated with type-specific prefixes (`weather_`, `soil_`, `thermo_hygro_`, `pool_thermo_`, `air_pm_`, `lightning_`, `leakage_`, `co2_`, `hcho_voc_`).

### Fix 2: HA device name does not reflect the user-defined sensor name

The HA device name was always `"Bresser <Model>"` regardless of any name assigned in `sensor_map`. The `sensor_map` name was already used for MQTT topics but never surfaced in HA.

**Fix:** Add an optional `display_name` field to `struct sensor_info`. `publishAutoDiscovery()` uses it as the HA device name when set, falling back to `"manufacturer model"` otherwise. All sensor type branches pass `sensor_str` (derived from `sensorName()` / `sensor_map`) as `display_name`.

```cpp
struct sensor_info {
    const char* manufacturer;
    const char* model;
    const char* identifier;
    const char* display_name; // optional: overrides "manufacturer model" as HA device name
};
```

## Compatibility

- Both fixes are backward-compatible: single-sensor setups see no behaviour change.
- `display_name` is optional (guarded by null/empty check), so any existing callers of `publishAutoDiscovery()` outside `haAutoDiscovery()` are unaffected.
- **Existing HA installations:** because only `device.identifiers` changes (not the entity `unique_id` or state topic), HA will migrate existing entities to the new device grouping automatically on the next discovery. An empty orphan device with the old hardcoded identifier may remain in the HA device registry and can be safely deleted manually.

## How to test

1. Define 2+ sensors of the same type in `sensor_map` with distinct names.
2. Flash and open **Settings → Devices & Services → MQTT** in Home Assistant.
3. Confirm each physical sensor appears as a **separate device** named after its `sensor_map` entry (e.g. "ThermoHygro-Garden", "ThermoHygro-Cellar").
4. If a stale empty device from a previous flash remains, delete it manually.